### PR TITLE
【旧】gh-1  gitignoreの追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# hidden/temp files
+.DS_Store
+*.swp
+*~.nib
+*.bk
+temp.plist
+
+# Build dir
+build/
+
+# Xcode project files except for the project file
+# *.xcodeproj/*
+# !*.xcodeproj/project.pbxproj
+# !*.xcodeproj/xcshareddata
+xcuserdata
+xcuserstate
+
+# Windows image thumbnail file
+Thumbs.db
+
+# User-specific project settings
+*.mode1v3
+*.mode2v3
+
+vendor/bundle
+*.generated.swift
+/Pods/


### PR DESCRIPTION
## 参考
gh-1

## 概要
- git管理の対象から余計なディレクトリを外す
- git管理しなくても良い差分を管理すると、コンフリクトの原因になるため不要なものは管理しない