### PR TITLE
gh-1 gitignoreの追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,38 @@
+# Xcode
+## Mac OS X
+.DS_Store
+## Xcode build files
+build/
+DerivedData/
+## Xcode settings
+*.pbxuser
+*.mode1v3
+*.mode2v3
+*.perspectivev3
+!default.pbxuser
+!default.mode1v3
+!default.mode2v3
+!default.perspectivev3*.xcodeproj/*
+## App packaging
+*.ipa
+*.dSYM.zip
+*.dSYM
+## Xcode Patch
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/
+!*.xcworkspace/contents.xcworkspacedata
+## library
+Pods/*
+Carthage/Build/
+## Other
+*.moved-aside
+*.xccheckout
+*.xcscmblueprint
+*.xcuserstate
+*.swp
+xcuserdata/
+*.moved-aside
+!.gitkeep
+
+vendor/bundle


### PR DESCRIPTION
## 参考
gh-1

## 概要
- git管理の対象から余計なディレクトリを外す
- git管理しなくても良い差分を管理すると、コンフリクトの原因になるため不要なものは管理しない